### PR TITLE
fix breadcrumbs to populate params in matched routes

### DIFF
--- a/src/vue-2-breadcrumbs.js
+++ b/src/vue-2-breadcrumbs.js
@@ -1,26 +1,35 @@
 export default {
-	install(Vue) {
-		Object.defineProperties(Vue.prototype, {
-			$breadcrumbs: {
-				get() {
-					return this.$route.matched;
-				}
-			}
-		});
+  install (Vue) {
+    Object.defineProperties(Vue.prototype, {
+      $breadcrumbs: {
+        get () {
+          return this.$route.matched.map(r => {
+            let path = ''
+            let route = r
 
-		Vue.component('breadcrumbs', {
-			methods: {
-				getBreadcrumb: function (bc) {
-					return typeof bc === 'function' ? bc() : bc;
-				}
-			},
-			template: `
-				<ol class="breadcrumb" v-if="$breadcrumbs.length">
-					<li class="breadcrumb-item" v-if="crumb.meta.breadcrumb" v-for="(crumb, i) in $breadcrumbs">
-						<router-link active-class="active" :to="{ path: crumb.path }" :tag="i != $breadcrumbs.length - 1 ? 'a' : 'span'">{{ getBreadcrumb(crumb.meta.breadcrumb) }}</router-link>
-					</li>
-				</ol>
-				`
-		});
-	}
-};
+            Object.keys(this.$route.params).map(e => {
+              path = route.path.replace(':' + e, this.$route.params[e])
+            }, this)
+            route.path = path
+            return route
+          }, this)
+        }
+      }
+    })
+
+    Vue.component('breadcrumbs', {
+      methods: {
+        getBreadcrumb: function (bc) {
+          return typeof bc === 'function' ? bc() : bc
+        }
+      },
+      template: `
+        <ol class="breadcrumb" v-if="$breadcrumbs.length">
+          <li class="breadcrumb-item" v-if="crumb.meta.breadcrumb" v-for="(crumb, i) in $breadcrumbs">
+            <router-link active-class="active" :to="{ path: crumb.path }" :tag="i != $breadcrumbs.length - 1 ? 'a' : 'span'">{{ getBreadcrumb(crumb.meta.breadcrumb) }}</router-link>
+          </li>
+        </ol>
+        `
+    })
+  }
+}


### PR DESCRIPTION
Your current breadcrumb library doesn't deal with parameters set in the path of a route.  I updated the code so that it will switch the :params with the value from the route.