### PR TITLE
fix: fix replace params

### DIFF
--- a/src/vue-2-breadcrumbs.js
+++ b/src/vue-2-breadcrumbs.js
@@ -8,7 +8,7 @@ export default {
             let route = routeRecord;
 
             Object.keys(this.$route.params).forEach(param => {
-              path = route.path.replace(':' + param, this.$route.params[param]);
+              path = path.replace(':' + param, this.$route.params[param]);
             }, this);
 
             route.path = path;


### PR DESCRIPTION
the original form replaces only the last param, because always use the original path instead of the updated