### PR TITLE
No li with blank breadcrumb

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ class VueBreadcrumbs implements PluginObject<ComponentOptions<Vue>> {
             },
             this.$breadcrumbs.map((crumb: RouteRecord, index: number) => {
               if (crumb?.meta?.breadcrumb) {
-                if (typeof crumb?.meta?.breadcrumb === 'string' && crumb?.meta?.breadcrumb === '') {
+                if (this.getBreadcrumb(crumb.meta.breadcrumb) === '') {
                   console.log('Breadcrumb blank. Ignoring');
                 } else {
                   console.log('Breadcrumb valid', crumb?.meta?.breadcrumb);

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,10 +77,8 @@ class VueBreadcrumbs implements PluginObject<ComponentOptions<Vue>> {
             this.$breadcrumbs.map((crumb: RouteRecord, index: number) => {
               if (crumb?.meta?.breadcrumb) {
                 let label = this.getBreadcrumb(crumb.meta.breadcrumb);
-                if (label === '') {
-                  console.log('Breadcrumb blank. Ignoring');
-                } else {
-                  console.log('Breadcrumb valid', crumb?.meta?.breadcrumb);
+                if (label !== '') {
+                  
                   return createElement(
                     'li',
                     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ class VueBreadcrumbs implements PluginObject<ComponentOptions<Vue>> {
               if (crumb?.meta?.breadcrumb) {
                 let label = this.getBreadcrumb(crumb.meta.breadcrumb);
                 if (label !== '') {
-                  
+
                   return createElement(
                     'li',
                     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,8 @@ class VueBreadcrumbs implements PluginObject<ComponentOptions<Vue>> {
             },
             this.$breadcrumbs.map((crumb: RouteRecord, index: number) => {
               if (crumb?.meta?.breadcrumb) {
-                if (this.getBreadcrumb(crumb.meta.breadcrumb) === '') {
+                let label = this.getBreadcrumb(crumb.meta.breadcrumb);
+                if (label === '') {
                   console.log('Breadcrumb blank. Ignoring');
                 } else {
                   console.log('Breadcrumb valid', crumb?.meta?.breadcrumb);
@@ -99,7 +100,7 @@ class VueBreadcrumbs implements PluginObject<ComponentOptions<Vue>> {
                             tag: index !== this.$breadcrumbs.length - 1 ? 'a' : 'span'
                           }
                         },
-                        ` ${this.getBreadcrumb(crumb.meta.breadcrumb)}`
+                        ` ${label}`
                       )
                     ]
                   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,10 @@ class VueBreadcrumbs implements PluginObject<ComponentOptions<Vue>> {
             },
             this.$breadcrumbs.map((crumb: RouteRecord, index: number) => {
               if (crumb?.meta?.breadcrumb) {
-                if (!(typeof crumb?.meta?.breadcrumb === 'string' && crumb?.meta?.breadcrumb === '')) {
+                if (typeof crumb?.meta?.breadcrumb === 'string' && crumb?.meta?.breadcrumb === '') {
+                  console.log('Breadcrumb blank. Ignoring');
+                } else {
+                  console.log('Breadcrumb valid', crumb?.meta?.breadcrumb);
                   return createElement(
                     'li',
                     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {ComponentOptions, PluginObject, VueConstructor, VNode} from 'vue'
+import { ComponentOptions, PluginObject, VueConstructor, VNode } from 'vue'
 
 import { RouteRecord } from 'vue-router';
 
@@ -25,7 +25,7 @@ class VueBreadcrumbs implements PluginObject<ComponentOptions<Vue>> {
               let routeRecord: RouteRecord[] = [route];
 
               if (route.meta?.breadcrumb?.parent) {
-                const matched = this.$router.resolve({name: route.meta.breadcrumb.parent}).route.matched
+                const matched = this.$router.resolve({ name: route.meta.breadcrumb.parent }).route.matched
 
                 routeRecord = [...matched, ...routeRecord];
               }
@@ -56,7 +56,7 @@ class VueBreadcrumbs implements PluginObject<ComponentOptions<Vue>> {
           return name;
         },
         getPath(crumb: RouteRecord): string {
-          let {path} = crumb;
+          let { path } = crumb;
 
           for (const [key, value] of Object.entries(this.$route.params)) {
             path = path.replace(`:${key}`, value);
@@ -76,29 +76,31 @@ class VueBreadcrumbs implements PluginObject<ComponentOptions<Vue>> {
             },
             this.$breadcrumbs.map((crumb: RouteRecord, index: number) => {
               if (crumb?.meta?.breadcrumb) {
-                return createElement(
-                  'li',
-                  {
-                    class: {
-                      'breadcrumb-item': true
-                    },
-                    props: {
-                      key: index
-                    }
-                  },
-                  [
-                    createElement(
-                      'router-link',
-                      {
-                        props: {
-                          to: { path: this.getPath(crumb) },
-                          tag: index !== this.$breadcrumbs.length - 1 ? 'a' : 'span'
-                        }
+                if (!(typeof crumb?.meta?.breadcrumb === 'string' && crumb?.meta?.breadcrumb === '')) {
+                  return createElement(
+                    'li',
+                    {
+                      class: {
+                        'breadcrumb-item': true
                       },
-                      ` ${this.getBreadcrumb(crumb.meta.breadcrumb)}`
-                    )
-                  ]
-                )
+                      props: {
+                        key: index
+                      }
+                    },
+                    [
+                      createElement(
+                        'router-link',
+                        {
+                          props: {
+                            to: { path: this.getPath(crumb) },
+                            tag: index !== this.$breadcrumbs.length - 1 ? 'a' : 'span'
+                          }
+                        },
+                        ` ${this.getBreadcrumb(crumb.meta.breadcrumb)}`
+                      )
+                    ]
+                  )
+                }
               }
 
               return createElement();


### PR DESCRIPTION
This pull request prevents blank breadcrumbs from creating elements and separators. The reason is detailed in Issue #91 